### PR TITLE
Add constructor signature to FastifyError

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 export interface FastifyError extends Error {
+  new(): FastifyError
   code: string
   statusCode?: number
   validation?: ValidationResult[]


### PR DESCRIPTION
Without the constructor signature, typescript will error when you try and use the results of createError

<img width="675" alt="Screen Shot 2020-07-10 at 10 01 50 AM" src="https://user-images.githubusercontent.com/47506789/87162836-7ad5c600-c294-11ea-9dc1-3731e24ad5df.png">
