### PR TITLE
Widen type of ValidationResult to allow array params

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface ValidationResult {
   keyword: string
   dataPath: string
   schemaPath: string
-  params: Record<string, string>
+  params: Record<string, string | string[]>
   message: string
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,3 +7,8 @@ expectType<string>(error.code)
 expectType<string>(error.message)
 expectType<number>(error.statusCode!)
 expectType<ValidationResult[]>(error.validation!)
+
+expectType<ValidationResult['params']>({
+  stringParam: 'a',
+  stringArrayParam: ['a', 'b', 'c'],
+} as Record<string, string | string[]>);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,7 +8,8 @@ expectType<string>(error.message)
 expectType<number>(error.statusCode!)
 expectType<ValidationResult[]>(error.validation!)
 
-expectType<ValidationResult['params']>({
+const validationResultParams: Record<string, string | string[]> = {
   stringParam: 'a',
   stringArrayParam: ['a', 'b', 'c'],
-} as Record<string, string | string[]>);
+}
+expectType<ValidationResult['params']>(validationResultParams)


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify-error/issues/3

Can’t work out if using `as` in the [tsd](https://www.npmjs.com/package/tsd) tests is cheating 😄  Will defer to you.