### PR TITLE
fix: define typescript error constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,12 @@ export interface FastifyError extends Error {
   validation?: ValidationResult[]
 }
 
+export interface FastifyErrorConstructor extends ErrorConstructor {
+  new(a?: any, b?: any, c?: any): FastifyError;
+  (a?: any, b?: any, c?: any): FastifyError;
+  readonly prototype: FastifyError;
+}
+
 export interface ValidationResult {
   keyword: string
   dataPath: string
@@ -17,7 +23,7 @@ declare function createError (
   message: string,
   statusCode?: number,
   Base?: Error
-): FastifyError
+): FastifyErrorConstructor
 
 
-export default createError
+export default createError;

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,8 +22,9 @@ declare function createError (
   code: string,
   message: string,
   statusCode?: number,
-  Base?: Error
-): FastifyErrorConstructor
+  Base?: ErrorConstructor
+): typeof FastifyError
 
 
 export default createError;
+export { createError };

--- a/index.js
+++ b/index.js
@@ -41,3 +41,5 @@ function createError (code, message, statusCode = 500, Base = Error) {
 }
 
 module.exports = createError
+module.exports.default = createError
+module.exports.createError = createError

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,8 +1,7 @@
-import createError, { FastifyError, ValidationResult } from './'
+import createError, { createError as createErrorNamed, FastifyError, FastifyErrorConstructor, ValidationResult } from './'
 import { expectType } from 'tsd'
 
-const error = createError('CODE', 'message')
-expectType<FastifyError>(error)
+expectType<typeof createError>(createErrorNamed)
 
 const errorConstructor = createError('CODE', 'message')
 expectType<FastifyErrorConstructor>(errorConstructor)

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,10 +3,18 @@ import { expectType } from 'tsd'
 
 const error = createError('CODE', 'message')
 expectType<FastifyError>(error)
+
+const errorConstructor = createError('CODE', 'message')
+expectType<FastifyErrorConstructor>(errorConstructor)
+
+const error = new errorConstructor()
 expectType<string>(error.code)
 expectType<string>(error.message)
 expectType<number>(error.statusCode!)
 expectType<ValidationResult[]>(error.validation!)
+
+const errorWithoutNew = errorConstructor()
+expectType<FastifyError>(errorWithoutNew)
 
 const validationResultParams: Record<string, string | string[]> = {
   stringParam: 'a',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Type definitions where missing the constructor. There was another [open pr](https://github.com/fastify/fastify-error/pull/4) but the implementation had unresolved issues. I used the same a,b and c constructor argument names as the real js implementation uses but not 100% sure that those are descriptive enough. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
