### PR TITLE
Adds validationContext to FastifyError type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ export interface FastifyError extends Error {
   code: string
   statusCode?: number
   validation?: ValidationResult[]
+  validationContext?: string
 }
 
 export interface ValidationResult {
@@ -18,6 +19,5 @@ declare function createError (
   statusCode?: number,
   Base?: Error
 ): FastifyError
-
 
 export default createError

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,6 +6,7 @@ expectType<FastifyError>(error)
 expectType<string>(error.code)
 expectType<string>(error.message)
 expectType<number>(error.statusCode!)
+expectType<string>(error.validationContext!)
 expectType<ValidationResult[]>(error.validation!)
 
 const validationResultParams: Record<string, string | string[]> = {


### PR DESCRIPTION
Per the various examples on [these docs](https://github.com/fastify/fastify/blob/master/docs/Validation-and-Serialization.md), validationContext is often used to determine different error messages, especially when trying to inform the client which part of the input failed validation. This PR adds the validationContext property to the FastifyError

We could probably give the validationContext a union type with `'body' | 'params' | 'querystring' | 'headers'`. Thoughts?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
