### PR TITLE
Revert "performance patch"

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function createError (code, message, statusCode = 500, Base = Error) {
   code = code.toUpperCase()
 
   function FastifyError (a, b, c) {
-    if (!new.target) {
+    if (!(this instanceof FastifyError)) {
       return new FastifyError(a, b, c)
     }
     Error.captureStackTrace(this, FastifyError)


### PR DESCRIPTION
As discussed in https://github.com/nodejs/node/issues/42042#event-6101749430 it seems that the performance improvement has some implications and should be reverted.