### PR TITLE
Interpolate falsey values like `undefined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,21 +10,28 @@ function createError (code, message, statusCode = 500, Base = Error) {
 
   function FastifyError (a, b, c) {
     if (!new.target) {
-      return new FastifyError(a, b, c)
+      return new FastifyError(...arguments)
     }
     Error.captureStackTrace(this, FastifyError)
     this.name = 'FastifyError'
     this.code = code
 
     // more performant than spread (...) operator
-    if (a && b && c) {
-      this.message = format(message, a, b, c)
-    } else if (a && b) {
-      this.message = format(message, a, b)
-    } else if (a) {
-      this.message = format(message, a)
-    } else {
-      this.message = message
+    switch (arguments.length) {
+      case 3:
+        this.message = format(message, a, b, c)
+        break
+      case 2:
+        this.message = format(message, a, b)
+        break
+      case 1:
+        this.message = format(message, a)
+        break
+      case 0:
+        this.message = message
+        break
+      default:
+        this.message = format(message, ...arguments)
     }
 
     this.statusCode = statusCode || undefined

--- a/test.js
+++ b/test.js
@@ -27,7 +27,13 @@ test('Create error with 1 parameter', t => {
   t.truthy(err.stack)
 })
 
-test('Create error with 2 parameters', t => {
+test('Create error with 1 parameter set to undefined', t => {
+  const NewError = createError('CODE', 'hey %s')
+  const err = new NewError(undefined)
+  t.is(err.message, 'hey undefined')
+})
+
+test('Create error with 2 parameters', (t) => {
   const NewError = createError('CODE', 'hey %s, I like your %s')
   const err = new NewError('alice', 'attitude')
   t.true(err instanceof Error)
@@ -38,12 +44,27 @@ test('Create error with 2 parameters', t => {
   t.truthy(err.stack)
 })
 
+test('Create error with 2 parameters set to undefined', t => {
+  const NewError = createError('CODE', 'hey %s, I like your %s')
+  const err = new NewError(undefined, undefined)
+  t.is(err.message, 'hey undefined, I like your undefined')
+})
+
 test('Create error with 3 parameters', t => {
   const NewError = createError('CODE', 'hey %s, I like your %s %s')
   const err = new NewError('alice', 'attitude', 'see you')
   t.true(err instanceof Error)
   t.is(err.name, 'FastifyError')
   t.is(err.message, 'hey alice, I like your attitude see you')
+  t.is(err.code, 'CODE')
+  t.is(err.statusCode, 500)
+  t.truthy(err.stack)
+})
+
+test('Create error with 3 parameters set to undefined', t => {
+  const NewError = createError('CODE', 'hey %s, I like your %s %s')
+  const err = new NewError(undefined, undefined, undefined)
+  t.is(err.message, 'hey undefined, I like your undefined undefined')
   t.is(err.code, 'CODE')
   t.is(err.statusCode, 500)
   t.truthy(err.stack)


### PR DESCRIPTION
Fix the bug where a request to Fastify with no `Content-Type` header returns a misleading error message:

    Unsupported Media Type: %s

In this commit, I am changing the code determining the number of arguments to correctly detect when an argument was provided with an `undefined` value.

After this change, the error message becomes somewhat more useful:

    Unsupported Media Type: undefined

Resolves #67

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- (n/a) documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
