### PR TITLE
Rename module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fastify-error",
-  "version": "1.1.0",
+  "name": "@fastify/error",
+  "version": "2.0.0",
   "description": "A small utility, used by Fastify itself, for generating consistent error objects across your codebase and plugins.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -34,5 +34,8 @@
     "compilerOptions": {
       "esModuleInterop": true
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This pull request renames the module according to the discussion in
https://github.com/fastify/fastify/issues/3733.

Note that the deprecation module has _already been published_ and that the
code for it does not exist in this repository. The code for the published
deprecation module was generated by https://github.com/fastify/deprecate-modules
and run on @jsumners local system.

Coordinating the drastic changes to the code for the module deprecation and
then restoring the code for the module renaming would have been extremely
difficult and prohibitively tedious.

**Important:** no further releases should be added to the old major version.
