### PR TITLE
fix throws tests

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -111,13 +111,13 @@ test('Create error with no statusCode property', t => {
 test('Should throw when error code has no fastify code', t => {
   t.plan(1)
 
-  t.throws(() => createError(), 'Fastify error code must not be empty')
+  t.throws(() => createError(), new Error('Fastify error code must not be empty'))
 })
 
 test('Should throw when error code has no message', t => {
   t.plan(1)
 
-  t.throws(() => createError('code'), 'Fastify error message must not be empty')
+  t.throws(() => createError('code'), new Error('Fastify error message must not be empty'))
 })
 
 test('Create error with different base', t => {


### PR DESCRIPTION
small mistake in #82 

I wanted to actually check for the correct error, but it seems if it is only a string, tap will consider it as test-message if the test fails. This makes the whole throwing unit tests more strict.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
