### PR TITLE
perf: use spread operator

### DIFF
--- a/benchmarks/instantiate.js
+++ b/benchmarks/instantiate.js
@@ -4,9 +4,13 @@ const benchmark = require('benchmark')
 const createError = require('..')
 
 const FastifyError = createError('CODE', 'Not available')
+const FastifyError1 = createError('CODE', 'Not %s available')
+const FastifyError2 = createError('CODE', 'Not %s available %s')
 
 new benchmark.Suite()
   .add('instantiate Error', function () { new Error() }, { minSamples: 100 }) // eslint-disable-line no-new
   .add('instantiate FastifyError', function () { new FastifyError() }, { minSamples: 100 }) // eslint-disable-line no-new
+  .add('instantiate FastifyError arg 1', function () { new FastifyError1('q') }, { minSamples: 100 }) // eslint-disable-line no-new
+  .add('instantiate FastifyError arg 2', function () { new FastifyError2('qq', 'ss') }, { minSamples: 100 }) // eslint-disable-line no-new
   .on('cycle', function onCycle (event) { console.log(String(event.target)) })
   .run({ async: false })

--- a/benchmarks/no-stack.js
+++ b/benchmarks/no-stack.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const benchmark = require('benchmark')
-const createError = require('../types')
+const createError = require('..')
 
 const FastifyError = createError('CODE', 'Not available')
 Error.stackTraceLimit = 0

--- a/index.js
+++ b/index.js
@@ -9,31 +9,15 @@ function createError (code, message, statusCode = 500, Base = Error) {
   code = code.toUpperCase()
   !statusCode && (statusCode = undefined)
 
-  function FastifyError (a, b, c) {
+  function FastifyError (...args) {
     if (!new.target) {
-      return new FastifyError(...arguments)
+      return new FastifyError(...args)
     }
     this.code = code
     this.name = 'FastifyError'
     this.statusCode = statusCode
 
-    // more performant than spread (...) operator
-    switch (arguments.length) {
-      case 3:
-        this.message = format(message, a, b, c)
-        break
-      case 2:
-        this.message = format(message, a, b)
-        break
-      case 1:
-        this.message = format(message, a)
-        break
-      case 0:
-        this.message = message
-        break
-      default:
-        this.message = format(message, ...arguments)
-    }
+    this.message = format(message, ...args)
 
     Error.stackTraceLimit !== 0 && Error.captureStackTrace(this, FastifyError)
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


linux node16

```test
===before===
instantiate Error x 249,475 ops/sec ±2.40% (140 runs sampled)
instantiate FastifyError x 174,676 ops/sec ±0.74% (190 runs sampled)
instantiate FastifyError arg 1 x 150,298 ops/sec ±0.92% (186 runs sampled)
instantiate FastifyError arg 2 x 143,796 ops/sec ±1.38% (189 runs sampled)
```

```text
===after===
instantiate Error x 249,495 ops/sec ±2.23% (141 runs sampled)
instantiate FastifyError x 182,000 ops/sec ±1.09% (191 runs sampled)
instantiate FastifyError arg 1 x 151,138 ops/sec ±0.70% (190 runs sampled)
instantiate FastifyError arg 2 x 145,991 ops/sec ±1.09% (190 runs sampled)
```

linux node18

```
===before===
instantiate Error x 239,971 ops/sec ±2.18% (143 runs sampled)
instantiate FastifyError x 159,497 ops/sec ±1.76% (185 runs sampled)
instantiate FastifyError arg 1 x 127,290 ops/sec ±0.64% (191 runs sampled)
instantiate FastifyError arg 2 x 125,304 ops/sec ±1.01% (188 runs sampled)
```

```
===after===
instantiate Error x 242,392 ops/sec ±2.39% (148 runs sampled)
instantiate FastifyError x 169,641 ops/sec ±1.09% (191 runs sampled)
instantiate FastifyError arg 1 x 141,392 ops/sec ±0.74% (188 runs sampled)
instantiate FastifyError arg 2 x 139,401 ops/sec ±0.62% (191 runs sampled)
```

linux node20

```
===before===
instantiate Error x 229,342 ops/sec ±2.32% (144 runs sampled)
instantiate FastifyError x 167,544 ops/sec ±1.04% (188 runs sampled)
instantiate FastifyError arg 1 x 128,839 ops/sec ±1.32% (192 runs sampled)
instantiate FastifyError arg 2 x 128,528 ops/sec ±0.68% (189 runs sampled)
```

```
===after===
instantiate Error x 230,935 ops/sec ±2.04% (145 runs sampled)
instantiate FastifyError x 176,133 ops/sec ±1.12% (188 runs sampled)
instantiate FastifyError arg 1 x 134,350 ops/sec ±0.51% (192 runs sampled)
instantiate FastifyError arg 2 x 130,174 ops/sec ±1.43% (188 runs sampled)
```
