### PR TITLE
Remove ts-standard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "standard-with-typescript",
+  "parserOptions":  {
+    "project": "./tsconfig.eslint.json"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "types/index.d.ts",
   "scripts": {
-    "lint": "ts-standard",
+    "lint": "eslint --ext js,ts .",
     "test": "npm run test:unit && npm run test:typescript",
     "test:unit": "tap",
     "test:typescript": "tsd"
@@ -27,9 +27,15 @@
   },
   "homepage": "https://github.com/fastify/fastify-error#readme",
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.59.2",
+    "@typescript-eslint/parser": "^5.0.0",
     "benchmark": "^2.1.4",
+    "eslint": "^8.40.0",
+    "eslint-config-standard-with-typescript": "^34.0.1",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-n": "^15.0.0",
+    "eslint-plugin-promise": "^6.0.0",
     "tap": "^16.0.0",
-    "ts-standard": "^12.0.2",
     "tsd": "^0.28.0",
     "typescript": "^5.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "benchmark": "^2.1.4",
     "tap": "^16.0.0",
     "ts-standard": "^12.0.2",
-    "tsd": "^0.28.0"
+    "tsd": "^0.28.0",
+    "typescript": "^5.0.4"
   },
   "tsd": {
     "compilerOptions": {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import createError, { FastifyError, FastifyErrorConstructor } from '..'
+import createError, { type FastifyError, type FastifyErrorConstructor } from '..'
 import { expectType } from 'tsd'
 
 const CustomError = createError('ERROR_CODE', 'message')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

`standard` doesn't work will for typescript, use eslint with `eslint-config-standard-with-typescript` directly