### PR TITLE
perf: improve instantation speed by dynamic formatter generation

### DIFF
--- a/benchmarks/instantiate.js
+++ b/benchmarks/instantiate.js
@@ -3,10 +3,17 @@
 const benchmark = require('benchmark')
 const createError = require('..')
 
+
+Error.stackTraceLimit = 0
+
 const FastifyError = createError('CODE', 'Not available')
+const FastifySpecialError =  createError('CODE', '%s available')
+
+const Not = 'Not'
 
 new benchmark.Suite()
   .add('instantiate Error', function () { new Error() }, { minSamples: 100 }) // eslint-disable-line no-new
   .add('instantiate FastifyError', function () { new FastifyError() }, { minSamples: 100 }) // eslint-disable-line no-new
+  .add('instantiate FastifySpecialError', function () { new FastifySpecialError(Not) }, { minSamples: 100 }) // eslint-disable-line no-new
   .on('cycle', function onCycle (event) { console.log(String(event.target)) })
   .run({ async: false })

--- a/benchmarks/instantiate.js
+++ b/benchmarks/instantiate.js
@@ -3,11 +3,10 @@
 const benchmark = require('benchmark')
 const createError = require('..')
 
-
 Error.stackTraceLimit = 0
 
 const FastifyError = createError('CODE', 'Not available')
-const FastifySpecialError =  createError('CODE', '%s available')
+const FastifySpecialError = createError('CODE', '%s available')
 
 const Not = 'Not'
 

--- a/benchmarks/instantiate.js
+++ b/benchmarks/instantiate.js
@@ -15,7 +15,7 @@ const ss = 'ss'
 new benchmark.Suite()
   .add('instantiate Error', function () { new Error() }, { minSamples: 100 }) // eslint-disable-line no-new
   .add('instantiate FastifyError', function () { new FastifyError() }, { minSamples: 100 }) // eslint-disable-line no-new
-  .add('instantiate FastifyError arg 1', function () { new FastifyError1('q') }, { minSamples: 100 }) // eslint-disable-line no-new
-  .add('instantiate FastifyError arg 2', function () { new FastifyError2('qq', 'ss') }, { minSamples: 100 }) // eslint-disable-line no-new
+  .add('instantiate FastifyError arg 1', function () { new FastifyError1(q) }, { minSamples: 100 }) // eslint-disable-line no-new
+  .add('instantiate FastifyError arg 2', function () { new FastifyError2(qq, ss) }, { minSamples: 100 }) // eslint-disable-line no-new
   .on('cycle', function onCycle (event) { console.log(String(event.target)) })
   .run({ async: false })

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function createError (code, message, statusCode = 500, Base = Error) {
 
   function FastifyError () {
     if (!new.target) {
-      return new FastifyError(...args)
+      return new FastifyError(...arguments)
     }
     this.code = code
     this.name = 'FastifyError'

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { inherits, format } = require('util')
+const { inherits } = require('util')
+const formatFn = require('./lib/formatFn')
 
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
@@ -9,31 +10,16 @@ function createError (code, message, statusCode = 500, Base = Error) {
   code = code.toUpperCase()
   !statusCode && (statusCode = undefined)
 
-  function FastifyError (a, b, c) {
+  const format = formatFn(message)
+
+  function FastifyError () {
     if (!new.target) {
       return new FastifyError(...arguments)
     }
     this.code = code
     this.name = 'FastifyError'
     this.statusCode = statusCode
-
-    // more performant than spread (...) operator
-    switch (arguments.length) {
-      case 3:
-        this.message = format(message, a, b, c)
-        break
-      case 2:
-        this.message = format(message, a, b)
-        break
-      case 1:
-        this.message = format(message, a)
-        break
-      case 0:
-        this.message = message
-        break
-      default:
-        this.message = format(message, ...arguments)
-    }
+    this.message = format(arguments)
 
     Error.stackTraceLimit !== 0 && Error.captureStackTrace(this, FastifyError)
   }

--- a/lib/countSpecifiers.js
+++ b/lib/countSpecifiers.js
@@ -2,7 +2,7 @@
 
 const countSpecifiersRE = /%[sdifjoOc%]/g
 
-function countSpecifiers(message) {
+function countSpecifiers (message) {
   let result = 0
   message.replace(countSpecifiersRE, function (x) {
     if (x !== '%%') {

--- a/lib/countSpecifiers.js
+++ b/lib/countSpecifiers.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const countSpecifiersRE = /%[sdifjoOc%]/g
+
+function countSpecifiers(message) {
+  let result = 0
+  message.replace(countSpecifiersRE, function (x) {
+    if (x !== '%%') {
+      result++
+    }
+    return x
+  })
+
+  return result
+}
+
+module.exports = countSpecifiers

--- a/lib/formatFn.js
+++ b/lib/formatFn.js
@@ -4,8 +4,7 @@ const specifiersRE = /(%[sdifjoOc%])/g
 const inspect = require('util').inspect
 const countSpecifiers = require('./countSpecifiers')
 
-function formatFn(message) {
-
+function formatFn (message) {
   const specifiersAmount = countSpecifiers(message)
 
   let fnBody = `
@@ -48,14 +47,14 @@ function formatFn(message) {
         break
       case '%%':
         fnBody += ' + (argsLen === 0 ? "%%" : "%")'
-        break;
+        break
       case '%d':
         fnBody += ` + (
           ${argNum} >= argsLen && '%d' ||
           args[${argNum}]
         )`
         argNum++
-        break;
+        break
       case '%i':
         fnBody += ` + (
           ${argNum} >= argsLen && '%i' ||
@@ -69,14 +68,14 @@ function formatFn(message) {
           parseInt(args[${argNum}], 10)
         )`
         argNum++
-        break;
+        break
       case '%f':
         fnBody += ` + (
           ${argNum} >= argsLen && '%f' ||
           parseFloat(args[${argNum}])
         )`
         argNum++
-        break;
+        break
       case '%s':
         fnBody += ` + (
           ${argNum} >= argsLen && '%s' ||
@@ -87,32 +86,32 @@ function formatFn(message) {
           )
         )`
         argNum++
-        break;
+        break
       case '%o':
         fnBody += ` + (
           ${argNum} >= argsLen && '%o' ||
           inspect(args[${argNum}], oOptions)
         )`
         argNum++
-        break;
+        break
       case '%O':
         fnBody += ` + (
           ${argNum} >= argsLen && '%O' ||
           inspect(args[${argNum}])
         )`
         argNum++
-        break;
+        break
       case '%j':
         fnBody += ` + (
           ${argNum} >= argsLen && '%j' ||
           stringify(args[${argNum}])
         )`
         argNum++
-        break;
+        break
       case '%c':
-        break;
+        break
       default:
-        fnBody += "+ " + JSON.stringify(messagePart)
+        fnBody += '+ ' + JSON.stringify(messagePart)
     }
   }
 
@@ -120,8 +119,7 @@ function formatFn(message) {
 
   fnBody += '}'
 
-  return new Function('inspect', fnBody)(inspect)
+  return new Function('inspect', fnBody)(inspect) // eslint-disable-line no-new-func
 }
-
 
 module.exports = formatFn

--- a/lib/formatFn.js
+++ b/lib/formatFn.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const countSpecifiers = require("./countSpecifiers")
+const specifiersRE = /(%[sdifjoOc%])/g
+
+function formatFn(message) {
+  const amountOfPlaceholders = countSpecifiers(message)
+
+  if (amountOfPlaceholders === 0) {
+    return () => message
+  }
+  let fnBody = 'return ""'
+
+  let argNum = 0
+  const messageParts = message.split(specifiersRE)
+
+
+  for (let i = 0; i < messageParts.length; ++i) {
+    switch (messageParts[i]) {
+      case '':
+        break
+      case '%%':
+        fnBody += ' + "%"'
+        break;
+      case '%d':
+        fnBody += "+ args[" + argNum++ + "]"
+        break;
+      case '%i':
+        fnBody += "+ parseInt(args[" + argNum++ + "])"
+        break;
+      case '%f':
+        fnBody += "+ parseFloat(args[" + argNum++ + "])"
+        break;
+      case '%s':
+        fnBody += "+ args[" + argNum++ + "]"
+        break;
+      case '%j':
+        fnBody += "+ JSON.stringify(args[" + argNum++ + "])"
+        break;
+      default:
+        fnBody += "+ " + JSON.stringify(messageParts[i])
+    }
+  }
+
+  return new Function('args', fnBody)
+}
+
+
+module.exports = formatFn

--- a/lib/formatFn.js
+++ b/lib/formatFn.js
@@ -1,16 +1,12 @@
 'use strict'
 
-const countSpecifiers = require("./countSpecifiers")
 const specifiersRE = /(%[sdifjoOc%])/g
 const inspect = require('util').inspect
+const countSpecifiers = require('./countSpecifiers')
 
 function formatFn(message) {
-  const amountOfPlaceholders = countSpecifiers(message)
 
-  if (amountOfPlaceholders === 0) {
-    message = message.replace(/%%/g, '%')
-    return () => message
-  }
+  const specifiersAmount = countSpecifiers(message)
 
   let fnBody = `
   function stringify(value) {
@@ -27,6 +23,16 @@ function formatFn(message) {
 
   const oOptions = { showHidden: true, showProxy: true }
 
+  function rest (args) {
+    let result = ''
+    let i = ${specifiersAmount}
+    const argsLength = args.length
+    while (i < args.length) {
+      result += ' ' + args[i++]
+    }
+    return result
+  }
+
   return function format (args) {
 
     const argsLen = args.length
@@ -41,7 +47,7 @@ function formatFn(message) {
       case '':
         break
       case '%%':
-        fnBody += ' + "%"'
+        fnBody += ' + (argsLen === 0 ? "%%" : "%")'
         break;
       case '%d':
         fnBody += ` + (
@@ -74,7 +80,11 @@ function formatFn(message) {
       case '%s':
         fnBody += ` + (
           ${argNum} >= argsLen && '%s' ||
-          args[${argNum}]
+          (
+            (typeof args[${argNum}] === 'bigint' && args[${argNum}].toString() + 'n') ||
+            (typeof args[${argNum}] === 'number' && args[${argNum}] === 0 && 1 / args[${argNum}] === -Infinity && '-0') ||
+            args[${argNum}]
+          )
         )`
         argNum++
         break;
@@ -106,9 +116,11 @@ function formatFn(message) {
     }
   }
 
+  fnBody += '+ rest(args)'
+
   fnBody += '}'
 
-  return new Function(fnBody)(inspect)
+  return new Function('inspect', fnBody)(inspect)
 }
 
 

--- a/lib/formatFn.js
+++ b/lib/formatFn.js
@@ -2,47 +2,113 @@
 
 const countSpecifiers = require("./countSpecifiers")
 const specifiersRE = /(%[sdifjoOc%])/g
+const inspect = require('util').inspect
 
 function formatFn(message) {
   const amountOfPlaceholders = countSpecifiers(message)
 
   if (amountOfPlaceholders === 0) {
+    message = message.replace(/%%/g, '%')
     return () => message
   }
-  let fnBody = 'return ""'
+
+  let fnBody = `
+  function stringify(value) {
+    const stackTraceLimit = Error.stackTraceLimit
+    stackTraceLimit !== 0 && (Error.stackTraceLimit = 0)
+    try {
+      return JSON.stringify(value)
+    } catch (_e) {
+      return '[Circular]'
+    } finally {
+      stackTraceLimit !== 0 && (Error.stackTraceLimit = stackTraceLimit)
+    }
+  }
+
+  const oOptions = { showHidden: true, showProxy: true }
+
+  return function format (args) {
+
+    const argsLen = args.length
+
+    return ""`
 
   let argNum = 0
   const messageParts = message.split(specifiersRE)
 
-
-  for (let i = 0; i < messageParts.length; ++i) {
-    switch (messageParts[i]) {
+  for (const messagePart of messageParts) {
+    switch (messagePart) {
       case '':
         break
       case '%%':
         fnBody += ' + "%"'
         break;
       case '%d':
-        fnBody += "+ args[" + argNum++ + "]"
+        fnBody += ` + (
+          ${argNum} >= argsLen && '%d' ||
+          args[${argNum}]
+        )`
+        argNum++
         break;
       case '%i':
-        fnBody += "+ parseInt(args[" + argNum++ + "])"
+        fnBody += ` + (
+          ${argNum} >= argsLen && '%i' ||
+          typeof args[${argNum}] === 'number' && (
+            args[${argNum}] === Infinity && 'NaN' ||
+            args[${argNum}] === -Infinity && 'NaN' ||
+            args[${argNum}] !== args[${argNum}] && 'NaN' ||
+            '' + Math.trunc(args[${argNum}])
+          ) ||
+          typeof args[${argNum}] === 'bigint' && args[${argNum}] + 'n' ||
+          parseInt(args[${argNum}], 10)
+        )`
+        argNum++
         break;
       case '%f':
-        fnBody += "+ parseFloat(args[" + argNum++ + "])"
+        fnBody += ` + (
+          ${argNum} >= argsLen && '%f' ||
+          parseFloat(args[${argNum}])
+        )`
+        argNum++
         break;
       case '%s':
-        fnBody += "+ args[" + argNum++ + "]"
+        fnBody += ` + (
+          ${argNum} >= argsLen && '%s' ||
+          args[${argNum}]
+        )`
+        argNum++
+        break;
+      case '%o':
+        fnBody += ` + (
+          ${argNum} >= argsLen && '%o' ||
+          inspect(args[${argNum}], oOptions)
+        )`
+        argNum++
+        break;
+      case '%O':
+        fnBody += ` + (
+          ${argNum} >= argsLen && '%O' ||
+          inspect(args[${argNum}])
+        )`
+        argNum++
         break;
       case '%j':
-        fnBody += "+ JSON.stringify(args[" + argNum++ + "])"
+        fnBody += ` + (
+          ${argNum} >= argsLen && '%j' ||
+          stringify(args[${argNum}])
+        )`
+        argNum++
+        break;
+      case '%c':
         break;
       default:
-        fnBody += "+ " + JSON.stringify(messageParts[i])
+        fnBody += "+ " + JSON.stringify(messagePart)
     }
   }
 
-  return new Function('args', fnBody)
+  fnBody += '}'
+
+  return new Function(fnBody)(inspect)
 }
 
 

--- a/test/lib/countSpecifiers.test.js
+++ b/test/lib/countSpecifiers.test.js
@@ -24,6 +24,5 @@ test('countSpecifiers', t => {
       t.plan(1)
       t.equal(countSpecifiers(testCase), expected)
     })
-
   }
 })

--- a/test/lib/countSpecifiers.test.js
+++ b/test/lib/countSpecifiers.test.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const test = require('tap').test
+const countSpecifiers = require('../../lib/countSpecifiers')
+
+const testCases = [
+  ['no specifier', 0],
+  ['a string %s', 1],
+  ['a number %d', 1],
+  ['an integer %i', 1],
+  ['a float %f', 1],
+  ['as json %j', 1],
+  ['as object %o', 1],
+  ['as object %O', 1],
+  ['as css %c', 1],
+  ['not a specifier %%', 0],
+  ['mixed %s %%%s', 2]
+]
+test('countSpecifiers', t => {
+  t.plan(testCases.length)
+
+  for (const [testCase, expected] of testCases) {
+    t.test(testCase, t => {
+      t.plan(1)
+      t.equal(countSpecifiers(testCase), expected)
+    })
+
+  }
+})

--- a/test/lib/formtFn.test.js
+++ b/test/lib/formtFn.test.js
@@ -4,11 +4,27 @@ const test = require('tap').test
 const formatFn = require('../../lib/formatFn')
 const format = require('util').format
 
+const circular = {}
+circular.circular = circular
+
 const testCases = [
+  ['%%', [], '%'],
   ['no specifier', [], 'no specifier'],
   ['string %s', [0], 'string 0'],
-  // ['string %s', [0n], 'string 0n'],
-  ['string %s', ['yes'], 'string yes']
+  ['integer %i', [0n], 'integer 0n'],
+  ['integer %i', [Infinity], 'integer NaN'],
+  ['integer %i', [-Infinity], 'integer NaN'],
+  ['integer %i', [NaN], 'integer NaN'],
+  ['string %s', ['yes'], 'string yes'],
+  ['float %f', [0], 'float 0'],
+  ['float %f', [-0], 'float 0'],
+  ['float %f', [0.0000001], 'float 1e-7'],
+  ['float %f', [0.000001], 'float 0.000001'],
+  ['float %f', ['a'], 'float NaN'],
+  ['float %f', [{}], 'float NaN'],
+  ['json %j', [{}], 'json {}'],
+  ['json %j', [circular], 'json [Circular]'],
+  ['%s:%s', ['foo'], 'foo:%s']
 ]
 test('formatFn', t => {
   t.plan(testCases.length)
@@ -24,7 +40,7 @@ test('formatFn', t => {
 test('format compatibility', t => {
   t.plan(testCases.length)
 
-  for (const [testCase, args, expected] of testCases) {
+  for (const [testCase, args] of testCases) {
     t.test(testCase, t => {
       t.plan(1)
       t.equal(formatFn(testCase)(args), format(testCase, ...args))

--- a/test/lib/formtFn.test.js
+++ b/test/lib/formtFn.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const test = require('tap').test
+const formatFn = require('../../lib/formatFn')
+const format = require('util').format
+
+const testCases = [
+  ['no specifier', [], 'no specifier'],
+  ['string %s', [0], 'string 0'],
+  // ['string %s', [0n], 'string 0n'],
+  ['string %s', ['yes'], 'string yes']
+]
+test('formatFn', t => {
+  t.plan(testCases.length)
+
+  for (const [testCase, args, expected] of testCases) {
+    t.test(testCase, t => {
+      t.plan(1)
+      t.equal(formatFn(testCase)(args), expected)
+    })
+  }
+})
+
+test('format compatibility', t => {
+  t.plan(testCases.length)
+
+  for (const [testCase, args, expected] of testCases) {
+    t.test(testCase, t => {
+      t.plan(1)
+      t.equal(formatFn(testCase)(args), format(testCase, ...args))
+    })
+  }
+})

--- a/test/lib/formtFn.test.js
+++ b/test/lib/formtFn.test.js
@@ -8,9 +8,18 @@ const circular = {}
 circular.circular = circular
 
 const testCases = [
-  ['%%', [], '%'],
+  ['%%', [], '%%'],
+  ['%% %s', [], '%% %s'],
+  ['%% %d', [2], '% 2'],
   ['no specifier', [], 'no specifier'],
   ['string %s', [0], 'string 0'],
+  ['string %s', [-0], 'string -0'],
+  ['string %s', [0n], 'string 0n'],
+  ['string %s', [Infinity], 'string Infinity'],
+  ['string %s', [-Infinity], 'string -Infinity'],
+  ['string %s', [-NaN], 'string NaN'],
+  ['string %s', [undefined], 'string undefined'],
+  ['%s', [{ toString: () => 'Foo' }], 'Foo'],
   ['integer %i', [0n], 'integer 0n'],
   ['integer %i', [Infinity], 'integer NaN'],
   ['integer %i', [-Infinity], 'integer NaN'],
@@ -24,25 +33,19 @@ const testCases = [
   ['float %f', [{}], 'float NaN'],
   ['json %j', [{}], 'json {}'],
   ['json %j', [circular], 'json [Circular]'],
-  ['%s:%s', ['foo'], 'foo:%s']
+  ['%s:%s', ['foo'], 'foo:%s'],
+  ['%s:%c', ['foo', 'bar'], 'foo:'],
+  ['%o', [{}], '{}'],
+  ['%O', [{}], '{}'],
+  ['1', [2, 3], '1 2 3']
 ]
 test('formatFn', t => {
   t.plan(testCases.length)
 
   for (const [testCase, args, expected] of testCases) {
     t.test(testCase, t => {
-      t.plan(1)
+      t.plan(2)
       t.equal(formatFn(testCase)(args), expected)
-    })
-  }
-})
-
-test('format compatibility', t => {
-  t.plan(testCases.length)
-
-  for (const [testCase, args] of testCases) {
-    t.test(testCase, t => {
-      t.plan(1)
       t.equal(formatFn(testCase)(args), format(testCase, ...args))
     })
   }


### PR DESCRIPTION
As I see that @trim21 is active in this repo, I wanted to suggest a change, which has maybe more impact than #100

This is just a poc. It is not complete regarding the serialization. 

To have some useful performance benchmark, i disabled stacktrace generation.

before:
```sh
uzlopak@Battlestation:~/workspace/fastify-org/fastify-error$ node benchmarks/instantiate.js
instantiate Error x 5,245,780 ops/sec ±0.37% (192 runs sampled)
instantiate FastifyError x 238,523,493 ops/sec ±0.07% (196 runs sampled)
instantiate FastifySpecialError x 20,584,535 ops/sec ±0.54% (194 runs sampled)
```
after:
```sh
uzlopak@Battlestation:~/workspace/fastify-org/fastify-error$ node benchmarks/instantiate.js
instantiate Error x 5,208,812 ops/sec ±0.22% (192 runs sampled)
instantiate FastifyError x 238,148,483 ops/sec ±0.08% (195 runs sampled)
instantiate FastifySpecialError x 144,541,760 ops/sec ±0.12% (194 runs sampled)
```

Obviously it gets slower if type casting is feature complete. But I assume, that it is still faster than calling util.format every time. 
Maybe it is useless, as stacktrace is always the biggest perf bottleneck. But in the case, somebody disables stacktrace on production services (which is i think anyway best practice) it shoiuld have an impact on perf.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
