### PR TITLE
Fix type of Base argument to createError

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,22 +1,22 @@
-declare function createError<C extends string, SC extends number, Arg extends unknown[] = [any?, any?, any?]> (
+declare function createError<C extends string, SC extends number, Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
   code: C,
   message: string,
   statusCode: SC,
-  Base?: Error
+  Base?: new () => Err
 ): createError.FastifyErrorConstructor<{ code: C, statusCode: SC }, Arg>
 
-declare function createError<C extends string, Arg extends unknown[] = [any?, any?, any?]> (
+declare function createError<C extends string, Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
   code: C,
   message: string,
   statusCode?: number,
-  Base?: Error
+  Base?: new () => Err
 ): createError.FastifyErrorConstructor<{ code: C }, Arg>
 
-declare function createError<Arg extends unknown[] = [any?, any?, any?]> (
+declare function createError<Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
   code: string,
   message: string,
   statusCode?: number,
-  Base?: Error
+  Base?: new () => Err
 ): createError.FastifyErrorConstructor<{ code: string }, Arg>
 
 type CreateError = typeof createError

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -65,3 +65,7 @@ expectError(new CustomTypedArgError6('a', 'b'))
 expectError(new CustomTypedArgError6('a', 'b', 'c'))
 CustomTypedArgError6('a', 'b', 'c', 'd')
 expectError(new CustomTypedArgError6('a', 'b', 'c', 'd', 'e'))
+
+
+const CustomErrorWithErrorConstructor = createError('ERROR_CODE', 'message', 500, TypeError)
+expectType<FastifyErrorConstructor<{ code: 'ERROR_CODE', statusCode: 500 }>>(CustomErrorWithErrorConstructor)


### PR DESCRIPTION
This PR fixes the type of the Base argument to createError.

The previous type was `Error` which is the type of an Error value, but now it's used is as a constructor for a class that inherits from Error.

This change make the type of `Base` a constructor for a class that inherits from Error