### PR TITLE
Fix type of base argument create error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ createError(code, message [, statusCode [, Base]])
 - `code` (`string`, required) - The error code, you can access it later with `error.code`. For consistency, we recommend prefixing plugin error codes with `FST_`
 - `message` (`string`, required) - The error message. You can also use interpolated strings for formatting the message.
 - `statusCode` (`number`, optional) - The status code that Fastify will use if the error is sent via HTTP.
-- `Base` (`new () => Error`, optional) - The base error object that will be used. (eg `TypeError`, `RangeError`)
+- `Base` (`ErrorConstructor`, optional) - The base error object that will be used. (eg `TypeError`, `RangeError`)
 
 ```js
 const createError = require('@fastify/error')

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ createError(code, message [, statusCode [, Base]])
 - `code` (`string`, required) - The error code, you can access it later with `error.code`. For consistency, we recommend prefixing plugin error codes with `FST_`
 - `message` (`string`, required) - The error message. You can also use interpolated strings for formatting the message.
 - `statusCode` (`number`, optional) - The status code that Fastify will use if the error is sent via HTTP.
-- `Base` (`Error`, optional) - The base error object that will be used. (eg `TypeError`, `RangeError`)
+- `Base` (`new () => Error`, optional) - The base error object that will be used. (eg `TypeError`, `RangeError`)
 
 ```js
 const createError = require('@fastify/error')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,22 +1,22 @@
-declare function createError<C extends string, SC extends number, Arg extends unknown[] = [any?, any?, any?]> (
+declare function createError<C extends string, SC extends number, Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
   code: C,
   message: string,
   statusCode: SC,
-  Base?: Error
+  Base?: new () => Err
 ): createError.FastifyErrorConstructor<{ code: C, statusCode: SC }, Arg>
 
-declare function createError<C extends string, Arg extends unknown[] = [any?, any?, any?]> (
+declare function createError<C extends string, Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
   code: C,
   message: string,
   statusCode?: number,
-  Base?: Error
+  Base?: new () => Err
 ): createError.FastifyErrorConstructor<{ code: C }, Arg>
 
-declare function createError<Arg extends unknown[] = [any?, any?, any?]> (
+declare function createError<Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
   code: string,
   message: string,
   statusCode?: number,
-  Base?: Error
+  Base?: new () => Err
 ): createError.FastifyErrorConstructor<{ code: string }, Arg>
 
 type CreateError = typeof createError

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,22 +1,22 @@
-declare function createError<C extends string, SC extends number, Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
+declare function createError<C extends string, SC extends number, Arg extends unknown[] = [any?, any?, any?]> (
   code: C,
   message: string,
   statusCode: SC,
-  Base?: new () => Err
+  Base?: ErrorConstructor
 ): createError.FastifyErrorConstructor<{ code: C, statusCode: SC }, Arg>
 
-declare function createError<C extends string, Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
+declare function createError<C extends string, Arg extends unknown[] = [any?, any?, any?]> (
   code: C,
   message: string,
   statusCode?: number,
-  Base?: new () => Err
+  Base?: ErrorConstructor
 ): createError.FastifyErrorConstructor<{ code: C }, Arg>
 
-declare function createError<Arg extends unknown[] = [any?, any?, any?], Err extends Error = Error> (
+declare function createError<Arg extends unknown[] = [any?, any?, any?]> (
   code: string,
   message: string,
   statusCode?: number,
-  Base?: new () => Err
+  Base?: ErrorConstructor
 ): createError.FastifyErrorConstructor<{ code: string }, Arg>
 
 type CreateError = typeof createError

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -65,3 +65,7 @@ expectError(new CustomTypedArgError6('a', 'b'))
 expectError(new CustomTypedArgError6('a', 'b', 'c'))
 CustomTypedArgError6('a', 'b', 'c', 'd')
 expectError(new CustomTypedArgError6('a', 'b', 'c', 'd', 'e'))
+
+
+const CustomErrorWithErrorConstructor = createError('ERROR_CODE', 'message', 500, TypeError)
+expectType<FastifyErrorConstructor<{ code: 'ERROR_CODE', statusCode: 500 }>>(CustomErrorWithErrorConstructor)


### PR DESCRIPTION
This PR fixes the type of the Base argument to createError.

The previous type was Error which is the type of an Error value, but it's being used is as a constructor for a class that inherits from Error.

This change makes the type of Base a constructor for a class that inherits from Error so it's type matches it's usage and  documented examples.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
