### PR TITLE
improve perf of error creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 'use strict'
 
-const { inherits, format } = require('util')
+const { format } = require('util')
+
+function toString () {
+  return `${this.name} [${this.code}]: ${this.message}`
+}
 
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
@@ -22,13 +26,20 @@ function createError (code, message, statusCode = 500, Base = Error) {
     Error.stackTraceLimit !== 0 && Error.captureStackTrace(this, FastifyError)
   }
 
-  FastifyError.prototype[Symbol.toStringTag] = 'Error'
-
-  FastifyError.prototype.toString = function () {
-    return `${this.name} [${this.code}]: ${this.message}`
-  }
-
-  inherits(FastifyError, Base)
+  FastifyError.prototype = Object.create(Base.prototype, {
+    constructor: {
+      value: FastifyError,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    },
+    toString: {
+      value: toString
+    },
+    [Symbol.toStringTag]: {
+      value: 'Error'
+    }
+  })
 
   return FastifyError
 }

--- a/index.js
+++ b/index.js
@@ -32,14 +32,12 @@ function createError (code, message, statusCode = 500, Base = Error) {
       enumerable: false,
       writable: true,
       configurable: true
-    },
-    toString: {
-      value: toString
-    },
-    [Symbol.toStringTag]: {
-      value: 'Error'
     }
   })
+
+  FastifyError.prototype[Symbol.toStringTag] = 'Error'
+
+  FastifyError.prototype.toString = toString
 
   return FastifyError
 }


### PR DESCRIPTION
before:
 ```sh
node benchmarks/create.js 
create FastifyError x 470,358 ops/sec ±0.80% (190 runs sampled)
```
after:
```sh
node benchmarks/create.js 
create FastifyError x 564,507 ops/sec ±0.43% (191 runs sampled)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
