### PR TITLE
fix: cause last element index check

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function createError (code, message, statusCode = 500, Base = Error) {
     this.statusCode = statusCode
 
     const lastElement = args.length - 1
-    if (lastElement !== 1 && args[lastElement] && typeof args[lastElement] === 'object' && 'cause' in args[lastElement]) {
+    if (lastElement !== -1 && args[lastElement] && typeof args[lastElement] === 'object' && 'cause' in args[lastElement]) {
       this.cause = args.pop().cause
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -163,6 +163,16 @@ test('Create an error with cause', t => {
   t.equal(err.cause, cause)
 })
 
+test('Create an error with cause and message', t => {
+  t.plan(2)
+  const cause = new Error('HEY')
+  const NewError = createError('CODE', 'Not available: %s')
+  const err = NewError('foo', { cause })
+
+  t.ok(err instanceof Error)
+  t.equal(err.cause, cause)
+})
+
 test('Create an error with last argument null', t => {
   t.plan(2)
   const cause = new Error('HEY')


### PR DESCRIPTION
There was a bug introduced in one of the latest commits in PR https://github.com/fastify/fastify-error/pull/116, which replaces the `lastElement !== -1` check with `lastElement !== 1`, consequently breaking the `cause` property extraction for a message with a single parameter.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
