### PR TITLE
fix: migrate from tap to node test and c8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.2.1
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5.0.0
     with:
       license-check: true
       lint: true

--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 node --test",
     "test:typescript": "tsd"
   },
   "repository": {
@@ -30,8 +30,8 @@
   "homepage": "https://github.com/fastify/fastify-error#readme",
   "devDependencies": {
     "benchmark": "^2.1.4",
+    "c8": "^10.1.2",
     "standard": "^17.1.0",
-    "tap": "^18.7.1",
     "tsd": "^0.31.0"
   },
   "tsd": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -126,7 +126,7 @@ test('Should throw when error code has no message', (t) => {
 })
 
 test('Create error with different base', (t) => {
-  t.plan(6)
+  t.plan(7)
 
   const NewError = createError('CODE', 'hey %s', 500, TypeError)
   const err = new NewError('dude')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,99 +1,118 @@
 'use strict'
 
-const { test } = require('node:test')
+const test = require('node:test')
 const assert = require('node:assert')
 const createError = require('..')
 
 test('Create error with zero parameter', (t) => {
+  t.plan(6)
+
   const NewError = createError('CODE', 'Not available')
   const err = new NewError()
-  assert.ok(err instanceof Error)
-  assert.equal(err.name, 'FastifyError')
-  assert.equal(err.message, 'Not available')
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, 500)
-  assert.ok(err.stack)
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, 'Not available')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })
 
 test('Create error with 1 parameter', (t) => {
+  t.plan(6)
+
   const NewError = createError('CODE', 'hey %s')
   const err = new NewError('alice')
-  assert.ok(err instanceof Error)
-  assert.equal(err.name, 'FastifyError')
-  assert.equal(err.message, 'hey alice')
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, 500)
-  assert.ok(err.stack)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.message, 'hey alice')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })
 
 test('Create error with 1 parameter set to undefined', (t) => {
+  t.plan(1)
+
   const NewError = createError('CODE', 'hey %s')
   const err = new NewError(undefined)
-  assert.equal(err.message, 'hey undefined')
+  t.assert.equal(err.message, 'hey undefined')
 })
 
 test('Create error with 2 parameters', (t) => {
+  t.plan(6)
+
   const NewError = createError('CODE', 'hey %s, I like your %s')
   const err = new NewError('alice', 'attitude')
-  assert.ok(err instanceof Error)
-  assert.equal(err.name, 'FastifyError')
-  assert.equal(err.message, 'hey alice, I like your attitude')
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, 500)
-  assert.ok(err.stack)
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, 'hey alice, I like your attitude')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })
 
 test('Create error with 2 parameters set to undefined', (t) => {
+  t.plan(1)
+
   const NewError = createError('CODE', 'hey %s, I like your %s')
   const err = new NewError(undefined, undefined)
-  assert.equal(err.message, 'hey undefined, I like your undefined')
+  t.assert.equal(err.message, 'hey undefined, I like your undefined')
 })
 
 test('Create error with 3 parameters', (t) => {
+  t.plan(6)
+
   const NewError = createError('CODE', 'hey %s, I like your %s %s')
   const err = new NewError('alice', 'attitude', 'see you')
-  assert.ok(err instanceof Error)
-  assert.equal(err.name, 'FastifyError')
-  assert.equal(err.message, 'hey alice, I like your attitude see you')
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, 500)
-  assert.ok(err.stack)
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, 'hey alice, I like your attitude see you')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })
 
 test('Create error with 3 parameters set to undefined', (t) => {
+  t.plan(4)
+
   const NewError = createError('CODE', 'hey %s, I like your %s %s')
   const err = new NewError(undefined, undefined, undefined)
-  assert.equal(err.message, 'hey undefined, I like your undefined undefined')
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, 500)
-  assert.ok(err.stack)
+  t.assert.equal(err.message, 'hey undefined, I like your undefined undefined')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })
 
 test('Create error with 4 parameters set to undefined', (t) => {
+  t.plan(4)
+
   const NewError = createError('CODE', 'hey %s, I like your %s %s and %s')
   const err = new NewError(undefined, undefined, undefined, undefined)
-  assert.equal(
+  t.assert.equal(
     err.message,
     'hey undefined, I like your undefined undefined and undefined'
   )
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, 500)
-  assert.ok(err.stack)
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })
 
 test('Create error with no statusCode property', (t) => {
+  t.plan(6)
+
   const NewError = createError('CODE', 'hey %s', 0)
   const err = new NewError('dude')
-  assert.ok(err instanceof Error)
-  assert.equal(err.name, 'FastifyError')
-  assert.equal(err.message, 'hey dude')
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, undefined)
-  assert.ok(err.stack)
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, 'hey dude')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, undefined)
+  t.assert.ok(err.stack)
 })
 
 test('Should throw when error code has no fastify code', (t) => {
-  assert.throws(
+  t.plan(1)
+  t.assert.throws(
     () => createError(),
     new Error('Fastify error code must not be empty')
   )
@@ -107,57 +126,69 @@ test('Should throw when error code has no message', (t) => {
 })
 
 test('Create error with different base', (t) => {
+  t.plan(6)
+
   const NewError = createError('CODE', 'hey %s', 500, TypeError)
   const err = new NewError('dude')
-  assert.ok(err instanceof Error)
-  assert.ok(err instanceof TypeError)
-  assert.equal(err.name, 'FastifyError')
-  assert.equal(err.message, 'hey dude')
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, 500)
-  assert.ok(err.stack)
+  t.assert.ok(err instanceof Error)
+  t.assert.ok(err instanceof TypeError)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, 'hey dude')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })
 
 test('FastifyError.toString returns code', (t) => {
+  t.plan(1)
+
   const NewError = createError('CODE', 'foo')
   const err = new NewError()
-  assert.equal(err.toString(), 'FastifyError [CODE]: foo')
+  t.assert.equal(err.toString(), 'FastifyError [CODE]: foo')
 })
 
 test('Create the error without the new keyword', (t) => {
+  t.plan(6)
+
   const NewError = createError('CODE', 'Not available')
   const err = NewError()
-  assert.ok(err instanceof Error)
-  assert.equal(err.name, 'FastifyError')
-  assert.equal(err.message, 'Not available')
-  assert.equal(err.code, 'CODE')
-  assert.equal(err.statusCode, 500)
-  assert.ok(err.stack)
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, 'Not available')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })
 
 test('Create an error with cause', (t) => {
+  t.plan(2)
+
   const cause = new Error('HEY')
   const NewError = createError('CODE', 'Not available')
   const err = NewError({ cause })
 
-  assert.ok(err instanceof Error)
-  assert.equal(err.cause, cause)
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.cause, cause)
 })
 
 test('Create an error with cause and message', (t) => {
+  t.plan(2)
+
   const cause = new Error('HEY')
   const NewError = createError('CODE', 'Not available: %s')
   const err = NewError('foo', { cause })
 
-  assert.ok(err instanceof Error)
-  assert.equal(err.cause, cause)
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.cause, cause)
 })
 
 test('Create an error with last argument null', (t) => {
+  t.plan(2)
+
   const cause = new Error('HEY')
   const NewError = createError('CODE', 'Not available')
   const err = NewError({ cause }, null)
 
-  assert.ok(err instanceof Error)
-  assert.ifError(err.cause)
+  t.assert.ok(err instanceof Error)
+  t.assert.ifError(err.cause)
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const test = require('node:test')
-const assert = require('node:assert')
 const createError = require('..')
 
 test('Create error with zero parameter', (t) => {
@@ -119,7 +118,7 @@ test('Should throw when error code has no fastify code', (t) => {
 })
 
 test('Should throw when error code has no message', (t) => {
-  assert.throws(
+  t.assert.throws(
     () => createError('code'),
     new Error('Fastify error message must not be empty')
   )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,184 +1,163 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
+const assert = require('node:assert')
 const createError = require('..')
 
-test('Create error with zero parameter', t => {
-  t.plan(6)
-
+test('Create error with zero parameter', (t) => {
   const NewError = createError('CODE', 'Not available')
   const err = new NewError()
-  t.ok(err instanceof Error)
-  t.equal(err.name, 'FastifyError')
-  t.equal(err.message, 'Not available')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, 500)
-  t.ok(err.stack)
+  assert.ok(err instanceof Error)
+  assert.equal(err.name, 'FastifyError')
+  assert.equal(err.message, 'Not available')
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, 500)
+  assert.ok(err.stack)
 })
 
-test('Create error with 1 parameter', t => {
-  t.plan(6)
-
+test('Create error with 1 parameter', (t) => {
   const NewError = createError('CODE', 'hey %s')
   const err = new NewError('alice')
-  t.ok(err instanceof Error)
-  t.equal(err.name, 'FastifyError')
-  t.equal(err.message, 'hey alice')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, 500)
-  t.ok(err.stack)
+  assert.ok(err instanceof Error)
+  assert.equal(err.name, 'FastifyError')
+  assert.equal(err.message, 'hey alice')
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, 500)
+  assert.ok(err.stack)
 })
 
-test('Create error with 1 parameter set to undefined', t => {
-  t.plan(1)
-
+test('Create error with 1 parameter set to undefined', (t) => {
   const NewError = createError('CODE', 'hey %s')
   const err = new NewError(undefined)
-  t.equal(err.message, 'hey undefined')
+  assert.equal(err.message, 'hey undefined')
 })
 
 test('Create error with 2 parameters', (t) => {
-  t.plan(6)
-
   const NewError = createError('CODE', 'hey %s, I like your %s')
   const err = new NewError('alice', 'attitude')
-  t.ok(err instanceof Error)
-  t.equal(err.name, 'FastifyError')
-  t.equal(err.message, 'hey alice, I like your attitude')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, 500)
-  t.ok(err.stack)
+  assert.ok(err instanceof Error)
+  assert.equal(err.name, 'FastifyError')
+  assert.equal(err.message, 'hey alice, I like your attitude')
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, 500)
+  assert.ok(err.stack)
 })
 
-test('Create error with 2 parameters set to undefined', t => {
-  t.plan(1)
-
+test('Create error with 2 parameters set to undefined', (t) => {
   const NewError = createError('CODE', 'hey %s, I like your %s')
   const err = new NewError(undefined, undefined)
-  t.equal(err.message, 'hey undefined, I like your undefined')
+  assert.equal(err.message, 'hey undefined, I like your undefined')
 })
 
-test('Create error with 3 parameters', t => {
-  t.plan(6)
-
+test('Create error with 3 parameters', (t) => {
   const NewError = createError('CODE', 'hey %s, I like your %s %s')
   const err = new NewError('alice', 'attitude', 'see you')
-  t.ok(err instanceof Error)
-  t.equal(err.name, 'FastifyError')
-  t.equal(err.message, 'hey alice, I like your attitude see you')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, 500)
-  t.ok(err.stack)
+  assert.ok(err instanceof Error)
+  assert.equal(err.name, 'FastifyError')
+  assert.equal(err.message, 'hey alice, I like your attitude see you')
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, 500)
+  assert.ok(err.stack)
 })
 
-test('Create error with 3 parameters set to undefined', t => {
-  t.plan(4)
-
+test('Create error with 3 parameters set to undefined', (t) => {
   const NewError = createError('CODE', 'hey %s, I like your %s %s')
   const err = new NewError(undefined, undefined, undefined)
-  t.equal(err.message, 'hey undefined, I like your undefined undefined')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, 500)
-  t.ok(err.stack)
+  assert.equal(err.message, 'hey undefined, I like your undefined undefined')
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, 500)
+  assert.ok(err.stack)
 })
 
-test('Create error with 4 parameters set to undefined', t => {
-  t.plan(4)
-
+test('Create error with 4 parameters set to undefined', (t) => {
   const NewError = createError('CODE', 'hey %s, I like your %s %s and %s')
   const err = new NewError(undefined, undefined, undefined, undefined)
-  t.equal(err.message, 'hey undefined, I like your undefined undefined and undefined')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, 500)
-  t.ok(err.stack)
+  assert.equal(
+    err.message,
+    'hey undefined, I like your undefined undefined and undefined'
+  )
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, 500)
+  assert.ok(err.stack)
 })
 
-test('Create error with no statusCode property', t => {
-  t.plan(6)
-
+test('Create error with no statusCode property', (t) => {
   const NewError = createError('CODE', 'hey %s', 0)
   const err = new NewError('dude')
-  t.ok(err instanceof Error)
-  t.equal(err.name, 'FastifyError')
-  t.equal(err.message, 'hey dude')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, undefined)
-  t.ok(err.stack)
+  assert.ok(err instanceof Error)
+  assert.equal(err.name, 'FastifyError')
+  assert.equal(err.message, 'hey dude')
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, undefined)
+  assert.ok(err.stack)
 })
 
-test('Should throw when error code has no fastify code', t => {
-  t.plan(1)
-
-  t.throws(() => createError(), new Error('Fastify error code must not be empty'))
+test('Should throw when error code has no fastify code', (t) => {
+  assert.throws(
+    () => createError(),
+    new Error('Fastify error code must not be empty')
+  )
 })
 
-test('Should throw when error code has no message', t => {
-  t.plan(1)
-
-  t.throws(() => createError('code'), new Error('Fastify error message must not be empty'))
+test('Should throw when error code has no message', (t) => {
+  assert.throws(
+    () => createError('code'),
+    new Error('Fastify error message must not be empty')
+  )
 })
 
-test('Create error with different base', t => {
-  t.plan(7)
-
+test('Create error with different base', (t) => {
   const NewError = createError('CODE', 'hey %s', 500, TypeError)
   const err = new NewError('dude')
-  t.ok(err instanceof Error)
-  t.ok(err instanceof TypeError)
-  t.equal(err.name, 'FastifyError')
-  t.equal(err.message, 'hey dude')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, 500)
-  t.ok(err.stack)
+  assert.ok(err instanceof Error)
+  assert.ok(err instanceof TypeError)
+  assert.equal(err.name, 'FastifyError')
+  assert.equal(err.message, 'hey dude')
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, 500)
+  assert.ok(err.stack)
 })
 
-test('FastifyError.toString returns code', t => {
-  t.plan(1)
-
+test('FastifyError.toString returns code', (t) => {
   const NewError = createError('CODE', 'foo')
   const err = new NewError()
-  t.equal(err.toString(), 'FastifyError [CODE]: foo')
+  assert.equal(err.toString(), 'FastifyError [CODE]: foo')
 })
 
-test('Create the error without the new keyword', t => {
-  t.plan(6)
-
+test('Create the error without the new keyword', (t) => {
   const NewError = createError('CODE', 'Not available')
   const err = NewError()
-  t.ok(err instanceof Error)
-  t.equal(err.name, 'FastifyError')
-  t.equal(err.message, 'Not available')
-  t.equal(err.code, 'CODE')
-  t.equal(err.statusCode, 500)
-  t.ok(err.stack)
+  assert.ok(err instanceof Error)
+  assert.equal(err.name, 'FastifyError')
+  assert.equal(err.message, 'Not available')
+  assert.equal(err.code, 'CODE')
+  assert.equal(err.statusCode, 500)
+  assert.ok(err.stack)
 })
 
-test('Create an error with cause', t => {
-  t.plan(2)
+test('Create an error with cause', (t) => {
   const cause = new Error('HEY')
   const NewError = createError('CODE', 'Not available')
   const err = NewError({ cause })
 
-  t.ok(err instanceof Error)
-  t.equal(err.cause, cause)
+  assert.ok(err instanceof Error)
+  assert.equal(err.cause, cause)
 })
 
-test('Create an error with cause and message', t => {
-  t.plan(2)
+test('Create an error with cause and message', (t) => {
   const cause = new Error('HEY')
   const NewError = createError('CODE', 'Not available: %s')
   const err = NewError('foo', { cause })
 
-  t.ok(err instanceof Error)
-  t.equal(err.cause, cause)
+  assert.ok(err instanceof Error)
+  assert.equal(err.cause, cause)
 })
 
-test('Create an error with last argument null', t => {
-  t.plan(2)
+test('Create an error with last argument null', (t) => {
   const cause = new Error('HEY')
   const NewError = createError('CODE', 'Not available')
   const err = NewError({ cause }, null)
 
-  t.ok(err instanceof Error)
-  t.notOk(err.cause)
+  assert.ok(err instanceof Error)
+  assert.ifError(err.cause)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

Closes #129 

This PR migrates from `tap` to `node:test` and `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
