### PR TITLE
Support empty string messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ function createError (code, message, statusCode = 500, Base = Error) {
       this.cause = args.pop().cause
     }
 
-    this.message = format(message, ...args).trim()
+    if (message) args.unshift(message)
+    this.message = format(...args)
 
     Error.stackTraceLimit !== 0 && Error.captureStackTrace(this, FastifyError)
   }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function toString () {
 
 function createError (code, message, statusCode = 500, Base = Error) {
   if (!code) throw new Error('Fastify error code must not be empty')
-  if (!message) throw new Error('Fastify error message must not be empty')
+  if (message === null || message === undefined) throw new Error('Fastify error message must be defined')
 
   code = code.toUpperCase()
   !statusCode && (statusCode = undefined)
@@ -27,7 +27,7 @@ function createError (code, message, statusCode = 500, Base = Error) {
       this.cause = args.pop().cause
     }
 
-    this.message = format(message, ...args)
+    this.message = format(message, ...args).trim()
 
     Error.stackTraceLimit !== 0 && Error.captureStackTrace(this, FastifyError)
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -120,7 +120,7 @@ test('Should throw when error code has no fastify code', (t) => {
 test('Should throw when error code has no message', (t) => {
   t.assert.throws(
     () => createError('code'),
-    new Error('Fastify error message must not be empty')
+    new Error('Fastify error message must be defined')
   )
 })
 
@@ -190,4 +190,43 @@ test('Create an error with last argument null', (t) => {
 
   t.assert.ok(err instanceof Error)
   t.assert.ifError(err.cause)
+})
+
+test('Create error with zero parameters, empty message', (t) => {
+  t.plan(6)
+
+  const NewError = createError('CODE', '')
+  const err = new NewError()
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, '')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
+})
+
+test('Create error with one parameter, empty message', (t) => {
+  t.plan(6)
+
+  const NewError = createError('CODE', '')
+  const err = new NewError('alice')
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, 'alice')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
+})
+
+test('Create error with two parameters, empty message', (t) => {
+  t.plan(6)
+
+  const NewError = createError('CODE', '')
+  const err = new NewError('alice', 'attitude')
+  t.assert.ok(err instanceof Error)
+  t.assert.equal(err.name, 'FastifyError')
+  t.assert.equal(err.message, 'alice attitude')
+  t.assert.equal(err.code, 'CODE')
+  t.assert.equal(err.statusCode, 500)
+  t.assert.ok(err.stack)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR proposes supporting empty strings as messages to support the following use case:

```js
const MyError = createError("MY_CODE", "", 400)
// before -> throws error
// after -> works

throw new MyError() // message = ""
throw new MyError("broken") // message = "broken"
```

This supports the use case where the user doesn't desire any prefix or suffix to the message; they want the message to match the argument passed to the error.

The `trim()` I admit is a little problematic, but without it, the above example looks like:

```js
throw new MyError("broken") // message = " broken" (note the space)

```