### PR TITLE
feat: implement createRFC7807Error factory to support RFC7807

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,11 +90,39 @@ function createError (code, message, statusCode = 500, Base = Error, captureStac
   return FastifyError
 }
 
+function createRFC7807Error (
+  code,
+  message,
+  statusCode = 500,
+  opts = {},
+  Base = Error,
+  captureStackTrace = createError.captureStackTrace
+) {
+  const Err = createError(code, message, statusCode, Base, captureStackTrace)
+
+  Err.type = opts.type || 'about:blank'
+  Err.title = opts.title || 'FastifyError'
+
+  Err.prototype.toRFC7807 = function (instance = '', details = {}) {
+    return {
+      type: Err.type,
+      title: Err.title,
+      status: this.statusCode ?? statusCode,
+      detail: this.message,
+      instance,
+      code: this.code,
+      details
+    }
+  }
+  return Err
+}
+
 createError.captureStackTrace = true
 
 const FastifyErrorConstructor = createError(FastifyGenericErrorSymbol, 'Fastify Error', 500, Error)
 
 module.exports = createError
 module.exports.FastifyError = FastifyErrorConstructor
+module.exports.createRFC7807Error = createRFC7807Error
 module.exports.default = createError
 module.exports.createError = createError

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,9 @@ declare namespace createError {
   export interface FastifyError extends Error {
     code: string
     name: string
-    statusCode?: number
+    statusCode?: number,
+    toRFC7807?(instance?: string, details?: Record<string, any>): RFC7807Problem
+
   }
 
   export interface FastifyErrorConstructor<
@@ -38,6 +40,29 @@ declare namespace createError {
     new(...arg: T): FastifyError & E
     (...arg: T): FastifyError & E
     readonly prototype: FastifyError & E
+  }
+
+  export function createRFC7807Error<
+  C extends string,
+  SC extends number,
+  Arg extends unknown[] = [any?, any?, any?]
+> (
+    code: C,
+    message: string,
+    statusCode?: SC,
+    opts?: { type?: string; title?: string },
+    Base?: ErrorConstructor,
+    captureStackTrace?: boolean
+  ): createError.FastifyErrorConstructor<{ code: C; statusCode: SC }, Arg>
+
+  export interface RFC7807Problem {
+    type: string
+    title: string
+    status: number
+    detail: string
+    instance?: string
+    code: string
+    details?: Record<string, unknown>
   }
 
   export const FastifyError: FastifyErrorConstructor


### PR DESCRIPTION
This PR introduces a new createRFC7807Error factory method for creating errors compatible with RFC7807 

Test coverage included for default and custom scenarios

fixes: https://github.com/fastify/fastify-error/issues/64
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
